### PR TITLE
Update CHANGELOG.md

### DIFF
--- a/charts/ingress-nginx/CHANGELOG.md
+++ b/charts/ingress-nginx/CHANGELOG.md
@@ -4,7 +4,7 @@ This file documents all notable changes to [ingress-nginx](https://github.com/ku
 
 ### 4.3.0 
 - Support for Kubernetes v.1.25.0 was added and support for endpoint slices
-- Support for Kubernetes v1.20.0 was removed
+- Support for Kubernetes v1.20.0 and v1.21.0 was removed
 - [8890](https://github.com/kubernetes/ingress-nginx/pull/8890) migrate to endpointslices
 - [9059](https://github.com/kubernetes/ingress-nginx/pull/9059) kubewebhookcertgen sha change after go1191
 - [9046](https://github.com/kubernetes/ingress-nginx/pull/9046) Parameterize metrics port name


### PR DESCRIPTION
update the helm chart changelog to show that kubernetes v1.21.x is no longer supported.